### PR TITLE
Fixes Encoding on Terms and Conditions

### DIFF
--- a/lib/paysafe/account_management_service.rb
+++ b/lib/paysafe/account_management_service.rb
@@ -168,7 +168,7 @@ module Paysafe
       response = @client.process_request(request, raw_response: true)
       raw_version = response['x_terms_version']
       version = raw_version.present?  ? raw_version.split(" ").last : ""
-      {terms: response.body, version: version}
+      {terms: response.body.force_encoding('utf-8'), version: version}
     end
 
     def initiateIdentityVerification identityVerification

--- a/paysafe.gemspec
+++ b/paysafe.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = "Paysafe"
-  s.version     = "1.0.6"
+  s.version     = "1.0.7"
   s.date        = "2014-03-11"
   s.summary     = "Paysafe API"
   s.description = "Paysafe API integration with Ruby"


### PR DESCRIPTION
Sometimes the terms and conditions can return `ascii-8bit` instead of `utf-8`. This ensures the content is always utf-8.